### PR TITLE
Fix bugs in admin form

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -38,6 +38,6 @@ class Admin::UsersController < Admin::ApplicationController
   end
 
   def user_params
-    params.require(:user).permit :email, :age, :gender, interests_attributes: [:id, :name, :type, :_destroy]
+    params.require(:user).permit :email, :age, :gender, interests_attributes: [:id, :name, :category, :_destroy]
   end
 end

--- a/app/views/admin/users/_form.html.erb
+++ b/app/views/admin/users/_form.html.erb
@@ -18,7 +18,7 @@
   <div class="form-group">
     <%= f.label :gender, class: 'control-label col-md-4' %>
     <div class="col-md-8">
-      <%= f.select :gender, User.genders, {}, { class: 'form-control' } %>
+      <%= f.select :gender, User.genders.keys, {}, { class: 'form-control' } %>
     </div>
   </div>
 

--- a/app/views/admin/users/_interest_fields.html.erb
+++ b/app/views/admin/users/_interest_fields.html.erb
@@ -3,7 +3,7 @@
     <%= f.text_field :name, class: 'form-control' %>
   </div>
   <div class="col-md-4">
-    <%= f.select :category, Interest.categories, {}, { class: 'form-control' } %>
+    <%= f.select :category, Interest.categories.keys, {}, { class: 'form-control' } %>
   </div>
   <div class="col-md-2">
     <%= link_to_remove_association 'Remove', f, class: 'btn btn-danger btn-block' %>


### PR DESCRIPTION
Due missing feature specs, there was a bug in admin form which prevented from properly saving users gender and interests category.

This should not happen when #17 is completed.